### PR TITLE
Matrixmarket IO changes

### DIFF
--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -65,10 +65,10 @@ jobs:
       - name: test nalgebra-sparse
         # Manifest-path is necessary because cargo otherwise won't correctly forward features
         # We increase number of proptest cases to hopefully catch more potential bugs
-        run: PROPTEST_CASES=10000 cargo test --manifest-path=nalgebra-sparse/Cargo.toml --features compare,proptest-support
+        run: PROPTEST_CASES=10000 cargo test --manifest-path=nalgebra-sparse/Cargo.toml --features compare,proptest-support,io
       - name: test nalgebra-sparse (slow tests)
         # Unfortunately, the "slow-tests" take so much time that we need to run them with --release
-        run: PROPTEST_CASES=10000 cargo test --release --manifest-path=nalgebra-sparse/Cargo.toml --features compare,proptest-support,slow-tests slow
+        run: PROPTEST_CASES=10000 cargo test --release --manifest-path=nalgebra-sparse/Cargo.toml --features compare,proptest-support,io,slow-tests slow
   test-nalgebra-macros:
     runs-on: ubuntu-latest
     steps:

--- a/nalgebra-sparse/Cargo.toml
+++ b/nalgebra-sparse/Cargo.toml
@@ -15,6 +15,8 @@ license = "Apache-2.0"
 [features]
 proptest-support = ["proptest", "nalgebra/proptest-support"]
 compare = [ "matrixcompare-core" ]
+
+# Enable matrix market I/O
 io      = [ "pest", "pest_derive" ]
 
 # Enable to enable running some tests that take a lot of time to run

--- a/nalgebra-sparse/src/io/matrix_market.rs
+++ b/nalgebra-sparse/src/io/matrix_market.rs
@@ -436,7 +436,11 @@ impl FromStr for StorageScheme {
 
 /// Precheck if it's a valid header.
 ///
-/// For more details, please check Boisvert, Ronald F., Roldan Pozo, and Karin A. Remington. The matrix market formats: Initial design. Technical report, Applied and Computational Mathematics Division, NIST, 1996.  Section 3.
+/// For more details, please check
+///
+/// Boisvert, Ronald F., Roldan Pozo, and Karin A. Remington.
+/// The matrix market formats: Initial design.
+/// Technical report, Applied and Computational Mathematics Division, NIST, 1996.  Section 3.
 fn typecode_precheck(tc: &Typecode) -> Result<(), MatrixMarketError> {
     match tc {
         Typecode {

--- a/nalgebra-sparse/src/io/mod.rs
+++ b/nalgebra-sparse/src/io/mod.rs
@@ -1,7 +1,35 @@
-//! Parsers for various matrix formats.
+//! Functionality for importing and exporting sparse matrices to and from files.
 //!
-//! ## Matrix Market
-//! See the [website](https://math.nist.gov/MatrixMarket/formats.html) or the [paper](https://www.researchgate.net/publication/2630533_The_Matrix_Market_Exchange_Formats_Initial_Design) for more details about matrix market.
+//! **Available only when the `io` feature is enabled.**
+//!
+//! The following formats are currently supported:
+//!
+//! | Format                                          |  Import    |   Export   |
+//! | ------------------------------------------------|------------|------------|
+//! | [Matrix market](#matrix-market-format)          |  Yes       |    No      |
+//!
+//! [Matrix market]: https://math.nist.gov/MatrixMarket/formats.html
+//!
+//! ## Matrix Market format
+//!
+//! The Matrix Market format is a simple ASCII-based file format for sparse matrices, and was initially developed for
+//! the [NIST Matrix Market](https://math.nist.gov/MatrixMarket/), a repository of example sparse matrices.
+//! In later years it has largely been superseded by the
+//! [SuiteSparse Matrix Collection](https://sparse.tamu.edu/) (formerly University of Florida Sparse Matrix Collection),
+//! which also uses the Matrix Market file format.
+//!
+//! We currently offer functionality for importing a Matrix market file to an instance of a
+//! [CooMatrix](crate::CooMatrix) through the function [load_coo_from_matrix_market_file]. It is also possible to load
+//! a matrix stored in the matrix market format with the function [load_coo_from_matrix_market_str].
+//!
+//! Export is currently not implemented, but [planned](https://github.com/dimforge/nalgebra/issues/1037).
+//!
+//! Our implementation is based on the [format description](https://math.nist.gov/MatrixMarket/formats.html)
+//! on the Matrix Market website and the
+//! [following NIST whitepaper](https://math.nist.gov/MatrixMarket/reports/MMformat.ps):
+//!
+//! > Boisvert, Ronald F., Roldan Pozo, and Karin A. Remington.<br/>
+//! > "*The Matrix Market Exchange Formats: Initial Design.*" (1996).
 
 pub use self::matrix_market::{
     load_coo_from_matrix_market_file, load_coo_from_matrix_market_str, MatrixMarketError,

--- a/nalgebra-sparse/src/lib.rs
+++ b/nalgebra-sparse/src/lib.rs
@@ -19,6 +19,7 @@
 //! - Sparsity patterns in CSR and CSC matrices are explicitly represented by the
 //!   [SparsityPattern](pattern::SparsityPattern) type, which encodes the invariants of the
 //!   associated index data structures.
+//! - [Matrix market format support](`io`) when the `io` feature is enabled.
 //! - [proptest strategies](`proptest`) for sparse matrices when the feature
 //!   `proptest-support` is enabled.
 //! - [matrixcompare support](https://crates.io/crates/matrixcompare) for effortless

--- a/nalgebra-sparse/tests/unit.rs
+++ b/nalgebra-sparse/tests/unit.rs
@@ -1,6 +1,13 @@
 //! Unit tests
-#[cfg(any(not(feature = "proptest-support"), not(feature = "compare")))]
-compile_error!("Tests must be run with features `proptest-support` and `compare`");
+#[cfg(not(all(
+feature = "proptest-support",
+feature = "compare",
+feature = "io",
+)))]
+compile_error!(
+    "Please enable the `proptest-support`, `compare` and `io` features in order to compile and run the tests.
+     Example: `cargo test -p nalgebra-sparse --features proptest-support,compare,io`"
+);
 
 mod unit_tests;
 

--- a/nalgebra-sparse/tests/unit_tests/matrix_market.rs
+++ b/nalgebra-sparse/tests/unit_tests/matrix_market.rs
@@ -6,6 +6,24 @@ use nalgebra_sparse::CooMatrix;
 
 #[test]
 #[rustfmt::skip]
+fn test_matrixmarket_sparse_real_general_empty() {
+    // Test several valid zero-shapes of a matrix
+    let shapes = vec![ (0, 0), (1, 0), (0, 1) ];
+    let strings: Vec<String> = shapes
+        .into_iter()
+        .map(|(m, n)| format!("%%MatrixMarket matrix coordinate real general\n {} {} 0", m, n))
+        .collect();
+
+    for string in &strings {
+        let sparse_mat = load_coo_from_matrix_market_str::<f32>(string).unwrap();
+        assert_eq!(sparse_mat.nrows(), 0);
+        assert_eq!(sparse_mat.ncols(), 0);
+        assert_eq!(sparse_mat.nnz(), 0);
+    }
+}
+
+#[test]
+#[rustfmt::skip]
 fn test_matrixmarket_sparse_real_general() {
     let file_str = r#"
 %%MatrixMarket matrix CoOrdinate real general

--- a/nalgebra-sparse/tests/unit_tests/mod.rs
+++ b/nalgebra-sparse/tests/unit_tests/mod.rs
@@ -3,7 +3,6 @@ mod convert_serial;
 mod coo;
 mod csc;
 mod csr;
-#[cfg(feature = "io")]
 mod matrix_market;
 mod ops;
 mod pattern;


### PR DESCRIPTION
Improved documentation, renamed some types, added CI support and made some structural changes:

- Remove `From<pest::Error>` in order to eliminate Pest from the public API (it should be an internal implementation detail).
- Hide details of `MatrixMarketScalar` and make it a sealed trait. See commit message and documentation for more info.
- Add **failing** unit test for empty matrix import. This needs to be fixed before we can merge to `nalgebra-sparse`.

@losanc: have a look and see what you think about the proposed changes?